### PR TITLE
Web accessibility confirmation

### DIFF
--- a/webpage/templates/webpage/achecker_2017-05-17_15-55-16.html
+++ b/webpage/templates/webpage/achecker_2017-05-17_15-55-16.html
@@ -1,0 +1,2429 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<title>Web Accessibility Checker report</title>
+<meta name="author" content="AChecker - Web Accessibility Checker http://www.atutor.ca/achecker/" /> 
+	
+<style type="text/css">
+ul {font-family: Arial; margin-bottom: 0px; margin-top: 0px; margin-right: 0px;}
+li.msg_err, li.msg_info { font-family: Arial; margin-bottom: 20px;list-style: none;}
+span.msg{font-family: Arial; line-height: 150%;}
+code.input { margin-bottom: 2ex; background-color: #F8F8F8; line-height: 130%;}
+span.err_type{ padding: .1em .5em; font-size: smaller;}
+span.info_msg { line-height: 100%; color: blue; padding: 1em 1em; font-size: large; font-weight: bold;}
+span.congrats_msg { line-height: 120%; color: green; padding: 1em 1em; font-size: large; font-weight: bold; white-space: nowrap;}
+</style>
+</head>
+<body>
+<p>
+<strong>Result: </strong>
+<span style="background-color: yellow; border: solid green; padding-right: 1em; padding-left: 1em">CONDITIONAL PASS</span>&nbsp;&nbsp;
+<span style="color:red"><span style="font-weight: bold;">0 Errors&nbsp;&nbsp;0 Likely Problems&nbsp;&nbsp;143 Potential Problems&nbsp;&nbsp;</span></span>
+<strong><br />
+<strong>Guides: </strong><a title="WCAG 2.0 (Level AA)(link opens in a new window)" target="_new" href="https://achecker.ca/guideline/view_guideline.php?id=8">WCAG 2.0 (Level AA)(link opens in a new window)</a>&nbsp;&nbsp;
+</p>
+<h3>Accessibility Review</h3>
+<h4>Errors</h4>
+<div id="errors" style="margin-top:1em">
+	<ul><li class='msg_info'><span id='AC_congrats_msg_for_errors' class='congrats_msg'>
+						<img src='https://achecker.ca/images/feedback.gif' alt='Feedback' />  Congratulations! No known problems.
+					</span></ul></li>
+</div><br/><h4>Likely Problems</h4>
+<div id="likely_problems" style="margin-top:1em">
+	<ul><li class='msg_info'><span id='AC_congrats_msg_for_likely' class='congrats_msg'>
+						<img src='https://achecker.ca/images/feedback.gif' alt='Feedback' />  Congratulations! No likely problems.
+					</span></ul></li><ul>
+</ul>
+</div><br/><h4>Potential Problems</h4>
+<div id="potential_problems" style="margin-top:1em">
+	<ul>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 8, Column 7</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=54"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=54'); return false;" 
+               target="_new"><code>title</code> might not describe the document.</a>
+         </span>
+         <pre><code class="input">&lt;title&gt; A digital editions catalogue &lt;/title&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 39, Column 7</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=89"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=89'); return false;" 
+               target="_new"><code>script</code> user interface may not be accessible.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot; src=&quot;/static/webpage/libraries/jquery/jquery.js&quot;&gt;&lt;/script&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 39, Column 7</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=86"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=86'); return false;" 
+               target="_new"><code>script</code> may use color alone.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot; src=&quot;/static/webpage/libraries/jquery/jquery.js&quot;&gt;&lt;/script&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 39, Column 7</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=87"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=87'); return false;" 
+               target="_new"><code>script</code> may cause screen flicker.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot; src=&quot;/static/webpage/libraries/jquery/jquery.js&quot;&gt;&lt;/script&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 41, Column 7</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=89"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=89'); return false;" 
+               target="_new"><code>script</code> user interface may not be accessible.</a>
+         </span>
+         <pre><code class="input">&lt;script src=&quot;/static/webpage/libraries/scroll-to-top/js/ap-scroll-top.min.js&quot;&gt;&lt;/script&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 41, Column 7</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=86"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=86'); return false;" 
+               target="_new"><code>script</code> may use color alone.</a>
+         </span>
+         <pre><code class="input">&lt;script src=&quot;/static/webpage/libraries/scroll-to-top/js/ap-scroll-top.min.js&quot;&gt;&lt;/script&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 41, Column 7</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=87"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=87'); return false;" 
+               target="_new"><code>script</code> may cause screen flicker.</a>
+         </span>
+         <pre><code class="input">&lt;script src=&quot;/static/webpage/libraries/scroll-to-top/js/ap-scroll-top.min.js&quot;&gt;&lt;/script&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 45, Column 9</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=89"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=89'); return false;" 
+               target="_new"><code>script</code> user interface may not be accessible.</a>
+         </span>
+         <pre><code class="input">&lt;script src=&quot;/static/webpage/libraries/cool-share/plugin.js&quot;/&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 45, Column 9</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=86"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=86'); return false;" 
+               target="_new"><code>script</code> may use color alone.</a>
+         </span>
+         <pre><code class="input">&lt;script src=&quot;/static/webpage/libraries/cool-share/plugin.js&quot;/&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 45, Column 9</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=87"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=87'); return false;" 
+               target="_new"><code>script</code> may cause screen flicker.</a>
+         </span>
+         <pre><code class="input">&lt;script src=&quot;/static/webpage/libraries/cool-share/plugin.js&quot;/&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 47, Column 7</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=89"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=89'); return false;" 
+               target="_new"><code>script</code> user interface may not be accessible.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot;&gt;
+          var _paq = _paq || [];
+          _paq.push(['trackPageView ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 47, Column 7</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=86"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=86'); return false;" 
+               target="_new"><code>script</code> may use color alone.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot;&gt;
+          var _paq = _paq || [];
+          _paq.push(['trackPageView ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 47, Column 7</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=87"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=87'); return false;" 
+               target="_new"><code>script</code> may cause screen flicker.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot;&gt;
+          var _paq = _paq || [];
+          _paq.push(['trackPageView ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 61, Column 13</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=8"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=8'); return false;" 
+               target="_new"><code>img</code> element may require a long description.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;//clarin.oeaw.ac.at/piwik/piwik.php?idsite=31&quot; style=&quot;border:0;&quot; alt=&quot;&quot; /&gt;</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at//clarin.oeaw.ac.at/piwik/piwik.php?idsite=31" height="50" border="1" alt="" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 61, Column 13</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=14"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=14'); return false;" 
+               target="_new">Image may be using color alone.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;//clarin.oeaw.ac.at/piwik/piwik.php?idsite=31&quot; style=&quot;border:0;&quot; alt=&quot;&quot; /&gt;</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at//clarin.oeaw.ac.at/piwik/piwik.php?idsite=31" height="50" border="1" alt="" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 61, Column 13</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=178"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=178'); return false;" 
+               target="_new">Alt text does not convey the same information as the image.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;//clarin.oeaw.ac.at/piwik/piwik.php?idsite=31&quot; style=&quot;border:0;&quot; alt=&quot;&quot; /&gt;</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at//clarin.oeaw.ac.at/piwik/piwik.php?idsite=31" height="50" border="1" alt="" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 61, Column 13</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=251"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=251'); return false;" 
+               target="_new">Image may contain text with poor contrast.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;//clarin.oeaw.ac.at/piwik/piwik.php?idsite=31&quot; style=&quot;border:0;&quot; alt=&quot;&quot; /&gt;</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at//clarin.oeaw.ac.at/piwik/piwik.php?idsite=31" height="50" border="1" alt="" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 61, Column 13</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=11"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=11'); return false;" 
+               target="_new">Image may contain text that is not in Alt text.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;//clarin.oeaw.ac.at/piwik/piwik.php?idsite=31&quot; style=&quot;border:0;&quot; alt=&quot;&quot; /&gt;</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at//clarin.oeaw.ac.at/piwik/piwik.php?idsite=31" height="50" border="1" alt="" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 66, Column 9</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=89"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=89'); return false;" 
+               target="_new"><code>script</code> user interface may not be accessible.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot;&gt;
+            window.cookieconsent_options = {&quot;message&quot;:&quot;This website  ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 66, Column 9</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=86"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=86'); return false;" 
+               target="_new"><code>script</code> may use color alone.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot;&gt;
+            window.cookieconsent_options = {&quot;message&quot;:&quot;This website  ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 66, Column 9</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=87"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=87'); return false;" 
+               target="_new"><code>script</code> may cause screen flicker.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot;&gt;
+            window.cookieconsent_options = {&quot;message&quot;:&quot;This website  ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 69, Column 9</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=89"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=89'); return false;" 
+               target="_new"><code>script</code> user interface may not be accessible.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot; src=&quot;//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.9/cookiecons ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 69, Column 9</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=86"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=86'); return false;" 
+               target="_new"><code>script</code> may use color alone.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot; src=&quot;//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.9/cookiecons ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 69, Column 9</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=87"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=87'); return false;" 
+               target="_new"><code>script</code> may cause screen flicker.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot; src=&quot;//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.9/cookiecons ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 156, Column 3</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=248"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=248'); return false;" 
+               target="_new">Visual lists may not be properly marked.</a>
+         </span>
+         <pre><code class="input">&lt;body role=&quot;document&quot;&gt;
+    &lt;header&gt;
+    &lt;nav class=&quot;navbar navbar-default navbar-fixed-top&quot;&gt;
+      &lt; ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 156, Column 3</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=28"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=28'); return false;" 
+               target="_new">Document may be missing a "skip to content" link.</a>
+         </span>
+         <pre><code class="input">&lt;body role=&quot;document&quot;&gt;
+    &lt;header&gt;
+    &lt;nav class=&quot;navbar navbar-default navbar-fixed-top&quot;&gt;
+      &lt; ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 156, Column 3</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=271"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=271'); return false;" 
+               target="_new"><code>dir</code> attribute may be required to identify changes in text direction.</a>
+         </span>
+         <pre><code class="input">&lt;body role=&quot;document&quot;&gt;
+    &lt;header&gt;
+    &lt;nav class=&quot;navbar navbar-default navbar-fixed-top&quot;&gt;
+      &lt; ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 156, Column 3</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=184"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=184'); return false;" 
+               target="_new">Site missing site map.</a>
+         </span>
+         <pre><code class="input">&lt;body role=&quot;document&quot;&gt;
+    &lt;header&gt;
+    &lt;nav class=&quot;navbar navbar-default navbar-fixed-top&quot;&gt;
+      &lt; ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 156, Column 3</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=250"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=250'); return false;" 
+               target="_new">Text may refer to items by shape, size, or relative position alone.</a>
+         </span>
+         <pre><code class="input">&lt;body role=&quot;document&quot;&gt;
+    &lt;header&gt;
+    &lt;nav class=&quot;navbar navbar-default navbar-fixed-top&quot;&gt;
+      &lt; ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 156, Column 3</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=131"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=131'); return false;" 
+               target="_new">Long quotations may not be marked using the <code>blockquote</code> element.</a>
+         </span>
+         <pre><code class="input">&lt;body role=&quot;document&quot;&gt;
+    &lt;header&gt;
+    &lt;nav class=&quot;navbar navbar-default navbar-fixed-top&quot;&gt;
+      &lt; ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 156, Column 3</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=270"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=270'); return false;" 
+               target="_new">Unicode right-to-left marks or left-to-right marks may be required.</a>
+         </span>
+         <pre><code class="input">&lt;body role=&quot;document&quot;&gt;
+    &lt;header&gt;
+    &lt;nav class=&quot;navbar navbar-default navbar-fixed-top&quot;&gt;
+      &lt; ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 156, Column 3</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=262"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=262'); return false;" 
+               target="_new">Groups of links with a related purpose are not marked.</a>
+         </span>
+         <pre><code class="input">&lt;body role=&quot;document&quot;&gt;
+    &lt;header&gt;
+    &lt;nav class=&quot;navbar navbar-default navbar-fixed-top&quot;&gt;
+      &lt; ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 156, Column 3</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=276"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=276'); return false;" 
+               target="_new">Repeated components may not appear in the same relative order each time they appear.</a>
+         </span>
+         <pre><code class="input">&lt;body role=&quot;document&quot;&gt;
+    &lt;header&gt;
+    &lt;nav class=&quot;navbar navbar-default navbar-fixed-top&quot;&gt;
+      &lt; ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 156, Column 3</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=110"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=110'); return false;" 
+               target="_new">Words or phrases that are not in the document's primary language may not be identified.</a>
+         </span>
+         <pre><code class="input">&lt;body role=&quot;document&quot;&gt;
+    &lt;header&gt;
+    &lt;nav class=&quot;navbar navbar-default navbar-fixed-top&quot;&gt;
+      &lt; ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 172, Column 17</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/&quot;&gt;Home&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 172, Column 17</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/&quot;&gt;Home&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 175, Column 17</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/browsing/editions/&quot;&gt;Browse the Catalogue&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 175, Column 17</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/browsing/editions/&quot;&gt;Browse the Catalogue&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 180, Column 19</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;#&quot; class=&quot;dropdown-toggle&quot; data-toggle=&quot;dropdown&quot; role=&quot;button&quot; aria-haspopup=&quot;true&quot; aria-e ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 180, Column 19</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;#&quot; class=&quot;dropdown-toggle&quot; data-toggle=&quot;dropdown&quot; role=&quot;button&quot; aria-haspopup=&quot;true&quot; aria-e ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 184, Column 28</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/browsing/map/&quot;&gt;a map, A MAP!!!!&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 184, Column 28</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/browsing/map/&quot;&gt;a map, A MAP!!!!&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 187, Column 26</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/charts/barcharts/&quot;&gt;Bar Charts&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 187, Column 26</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/charts/barcharts/&quot;&gt;Bar Charts&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 190, Column 26</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/charts/piecharts/&quot;&gt;Pie Charts&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 190, Column 26</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/charts/piecharts/&quot;&gt;Pie Charts&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 193, Column 26</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/wordclouds/show/&quot;&gt;Word Clouds&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 193, Column 26</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/wordclouds/show/&quot;&gt;Word Clouds&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 196, Column 25</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/datamodel/&quot;&gt;Catalogue's Data Model&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 196, Column 25</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/datamodel/&quot;&gt;Catalogue's Data Model&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 204, Column 19</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;#&quot; class=&quot;dropdown-toggle&quot; data-toggle=&quot;dropdown&quot; role=&quot;button&quot; aria-haspopup=&quot;true&quot; aria-e ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 204, Column 19</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;#&quot; class=&quot;dropdown-toggle&quot; data-toggle=&quot;dropdown&quot; role=&quot;button&quot; aria-haspopup=&quot;true&quot; aria-e ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 208, Column 26</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/api/&quot;&gt;JSON&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 208, Column 26</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/api/&quot;&gt;JSON&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 211, Column 26</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/editions/institution-csv/&quot;&gt;Download Institution and Places (.csv)&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 211, Column 26</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/editions/institution-csv/&quot;&gt;Download Institution and Places (.csv)&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 219, Column 17</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/survey/&quot;&gt;Survey 2017&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 219, Column 17</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/survey/&quot;&gt;Survey 2017&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 224, Column 17</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/documentation/&quot;&gt;Documentation&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 224, Column 17</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/documentation/&quot;&gt;Documentation&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 227, Column 17</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/faq/&quot;&gt;FAQ&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 227, Column 17</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/faq/&quot;&gt;FAQ&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 230, Column 17</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/feedback/&quot;&gt;User Feedback&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 230, Column 17</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/feedback/&quot;&gt;User Feedback&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 233, Column 17</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/imprint/&quot;&gt;Imprint&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 233, Column 17</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/imprint/&quot;&gt;Imprint&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 237, Column 19</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/accounts/login/&quot;&gt;Log In&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 237, Column 19</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/accounts/login/&quot;&gt;Log In&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 248, Column 5</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=8"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=8'); return false;" 
+               target="_new"><code>img</code> element may require a long description.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/DigEds_Cat_logo_transp.png&quot; class=&quot;img-responsive&quot; alt=&quot;logo&quot; height=&quot; ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/DigEds_Cat_logo_transp.png" height="50" border="1" alt="logo" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 248, Column 5</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=14"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=14'); return false;" 
+               target="_new">Image may be using color alone.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/DigEds_Cat_logo_transp.png&quot; class=&quot;img-responsive&quot; alt=&quot;logo&quot; height=&quot; ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/DigEds_Cat_logo_transp.png" height="50" border="1" alt="logo" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 248, Column 5</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=178"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=178'); return false;" 
+               target="_new">Alt text does not convey the same information as the image.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/DigEds_Cat_logo_transp.png&quot; class=&quot;img-responsive&quot; alt=&quot;logo&quot; height=&quot; ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/DigEds_Cat_logo_transp.png" height="50" border="1" alt="logo" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 248, Column 5</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=251"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=251'); return false;" 
+               target="_new">Image may contain text with poor contrast.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/DigEds_Cat_logo_transp.png&quot; class=&quot;img-responsive&quot; alt=&quot;logo&quot; height=&quot; ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/DigEds_Cat_logo_transp.png" height="50" border="1" alt="logo" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 248, Column 5</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=11"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=11'); return false;" 
+               target="_new">Image may contain text that is not in Alt text.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/DigEds_Cat_logo_transp.png&quot; class=&quot;img-responsive&quot; alt=&quot;logo&quot; height=&quot; ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/DigEds_Cat_logo_transp.png" height="50" border="1" alt="logo" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 248, Column 5</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=16"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=16'); return false;" 
+               target="_new">Alt text is not empty and image may be decorative.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/DigEds_Cat_logo_transp.png&quot; class=&quot;img-responsive&quot; alt=&quot;logo&quot; height=&quot; ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/DigEds_Cat_logo_transp.png" height="50" border="1" alt="logo" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 250, Column 9</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/browsing/editions/&quot; class=&quot;btn btn-info btn-lg&quot; title=&quot;Click HERE to browse the editions o ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 250, Column 9</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;/browsing/editions/&quot; class=&quot;btn btn-info btn-lg&quot; title=&quot;Click HERE to browse the editions o ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 261, Column 191</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a target=&quot;_blank&quot; href=&quot;/documentation/&quot;&gt;Documentation&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 261, Column 191</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a target=&quot;_blank&quot; href=&quot;/documentation/&quot;&gt;Documentation&lt;/a&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 267, Column 9</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=44"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=44'); return false;" 
+               target="_new"><code>h3</code> may be used for formatting.</a>
+         </span>
+         <pre><code class="input">&lt;h3&gt;News items&lt;/h3&gt;</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 269, Column 383</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;http://rzblx10.uni-regensburg.de/dbinfo/detail.php?bib_id=allefreien&amp;colors=&amp;ocolors=&amp;lett= ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 269, Column 383</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;http://rzblx10.uni-regensburg.de/dbinfo/detail.php?bib_id=allefreien&amp;colors=&amp;ocolors=&amp;lett= ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 272, Column 84</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;https://opinio.ucl.ac.uk/s?s=48797&quot; target=&quot;_blank&quot; title=&quot;Opens in new tab&quot;&gt;Expectations o ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 272, Column 84</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;https://opinio.ucl.ac.uk/s?s=48797&quot; target=&quot;_blank&quot; title=&quot;Opens in new tab&quot;&gt;Expectations o ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 274, Column 128</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;http://dhawards.org/dhawards2016/results/&quot;&gt;DH Awards 2016 Best DH Data Visualization catego ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 274, Column 128</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;http://dhawards.org/dhawards2016/results/&quot;&gt;DH Awards 2016 Best DH Data Visualization catego ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 276, Column 240</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;https://tei2016app.acdh.oeaw.ac.at/pages/index.html&quot; target=&quot;_blank&quot; title=&quot;Opens in new ta ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 276, Column 240</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;https://tei2016app.acdh.oeaw.ac.at/pages/index.html&quot; target=&quot;_blank&quot; title=&quot;Opens in new ta ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 276, Column 386</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;http://tei2016.acdh.oeaw.ac.at/sites/default/files/Greta%20Franzini%2C%20Peter%20Andorfer%2 ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 276, Column 386</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;http://tei2016.acdh.oeaw.ac.at/sites/default/files/Greta%20Franzini%2C%20Peter%20Andorfer%2 ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 281, Column 17</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a class=&quot;twitter-timeline&quot;  href=&quot;https://twitter.com/hashtag/digEdsCat&quot; data-widget-id=&quot;8550920286 ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 281, Column 17</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a class=&quot;twitter-timeline&quot;  href=&quot;https://twitter.com/hashtag/digEdsCat&quot; data-widget-id=&quot;8550920286 ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 282, Column 17</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=89"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=89'); return false;" 
+               target="_new"><code>script</code> user interface may not be accessible.</a>
+         </span>
+         <pre><code class="input">&lt;script&gt;!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http' ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 282, Column 17</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=86"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=86'); return false;" 
+               target="_new"><code>script</code> may use color alone.</a>
+         </span>
+         <pre><code class="input">&lt;script&gt;!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http' ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 282, Column 17</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=87"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=87'); return false;" 
+               target="_new"><code>script</code> may cause screen flicker.</a>
+         </span>
+         <pre><code class="input">&lt;script&gt;!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http' ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 287, Column 43</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;https://search.google.com/search-console/mobile-friendly?id=8UA7fxY2iDMoX6w0qGIUNA&quot; target= ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 287, Column 43</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;https://search.google.com/search-console/mobile-friendly?id=8UA7fxY2iDMoX6w0qGIUNA&quot; target= ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 300, Column 11</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;https://acdh.oeaw.ac.at/acdh/&quot; class=&quot;navlink&quot; target=&quot;_blank&quot;&gt;
+              &lt;img src=&quot;/st ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 300, Column 11</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;https://acdh.oeaw.ac.at/acdh/&quot; class=&quot;navlink&quot; target=&quot;_blank&quot;&gt;
+              &lt;img src=&quot;/st ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 301, Column 15</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=8"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=8'); return false;" 
+               target="_new"><code>img</code> element may require a long description.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/ACDH_kurz_Weiss.png&quot; class=&quot;footer-logo&quot; alt=&quot;ACDH&quot; title=&quot;Austrian Ce ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/ACDH_kurz_Weiss.png" height="50" border="1" alt="ACDH" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 301, Column 15</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=14"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=14'); return false;" 
+               target="_new">Image may be using color alone.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/ACDH_kurz_Weiss.png&quot; class=&quot;footer-logo&quot; alt=&quot;ACDH&quot; title=&quot;Austrian Ce ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/ACDH_kurz_Weiss.png" height="50" border="1" alt="ACDH" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 301, Column 15</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=251"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=251'); return false;" 
+               target="_new">Image may contain text with poor contrast.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/ACDH_kurz_Weiss.png&quot; class=&quot;footer-logo&quot; alt=&quot;ACDH&quot; title=&quot;Austrian Ce ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/ACDH_kurz_Weiss.png" height="50" border="1" alt="ACDH" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 301, Column 15</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=11"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=11'); return false;" 
+               target="_new">Image may contain text that is not in Alt text.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/ACDH_kurz_Weiss.png&quot; class=&quot;footer-logo&quot; alt=&quot;ACDH&quot; title=&quot;Austrian Ce ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/ACDH_kurz_Weiss.png" height="50" border="1" alt="ACDH" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 301, Column 15</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=16"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=16'); return false;" 
+               target="_new">Alt text is not empty and image may be decorative.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/ACDH_kurz_Weiss.png&quot; class=&quot;footer-logo&quot; alt=&quot;ACDH&quot; title=&quot;Austrian Ce ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/ACDH_kurz_Weiss.png" height="50" border="1" alt="ACDH" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 301, Column 15</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=239"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=239'); return false;" 
+               target="_new"><code>img</code> has <code>title</code> attribute and image may be decorative.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/ACDH_kurz_Weiss.png&quot; class=&quot;footer-logo&quot; alt=&quot;ACDH&quot; title=&quot;Austrian Ce ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/ACDH_kurz_Weiss.png" height="50" border="1" alt="ACDH" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 305, Column 11</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;https://creativecommons.org/licenses/by/4.0/&quot; class=&quot;navlink&quot; target=&quot;_blank&quot;&gt;
+             ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 305, Column 11</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;https://creativecommons.org/licenses/by/4.0/&quot; class=&quot;navlink&quot; target=&quot;_blank&quot;&gt;
+             ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 306, Column 15</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=8"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=8'); return false;" 
+               target="_new"><code>img</code> element may require a long description.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/by-sa.png&quot; class=&quot;footer-logo&quot; alt=&quot;CC-BY-SA-4.0&quot; title=&quot;CC-BY-SA-4.0  ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/by-sa.png" height="50" border="1" alt="CC-BY-SA-4.0" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 306, Column 15</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=14"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=14'); return false;" 
+               target="_new">Image may be using color alone.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/by-sa.png&quot; class=&quot;footer-logo&quot; alt=&quot;CC-BY-SA-4.0&quot; title=&quot;CC-BY-SA-4.0  ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/by-sa.png" height="50" border="1" alt="CC-BY-SA-4.0" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 306, Column 15</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=251"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=251'); return false;" 
+               target="_new">Image may contain text with poor contrast.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/by-sa.png&quot; class=&quot;footer-logo&quot; alt=&quot;CC-BY-SA-4.0&quot; title=&quot;CC-BY-SA-4.0  ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/by-sa.png" height="50" border="1" alt="CC-BY-SA-4.0" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 306, Column 15</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=11"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=11'); return false;" 
+               target="_new">Image may contain text that is not in Alt text.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/by-sa.png&quot; class=&quot;footer-logo&quot; alt=&quot;CC-BY-SA-4.0&quot; title=&quot;CC-BY-SA-4.0  ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/by-sa.png" height="50" border="1" alt="CC-BY-SA-4.0" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 306, Column 15</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=16"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=16'); return false;" 
+               target="_new">Alt text is not empty and image may be decorative.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/by-sa.png&quot; class=&quot;footer-logo&quot; alt=&quot;CC-BY-SA-4.0&quot; title=&quot;CC-BY-SA-4.0  ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/by-sa.png" height="50" border="1" alt="CC-BY-SA-4.0" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 306, Column 15</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=239"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=239'); return false;" 
+               target="_new"><code>img</code> has <code>title</code> attribute and image may be decorative.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/by-sa.png&quot; class=&quot;footer-logo&quot; alt=&quot;CC-BY-SA-4.0&quot; title=&quot;CC-BY-SA-4.0  ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/by-sa.png" height="50" border="1" alt="CC-BY-SA-4.0" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 310, Column 11</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;https://github.com/acdh-oeaw/dig_ed_cat&quot; class=&quot;navlink&quot; target=&quot;_blank&quot;&gt;
+              &lt;im ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 310, Column 11</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;https://github.com/acdh-oeaw/dig_ed_cat&quot; class=&quot;navlink&quot; target=&quot;_blank&quot;&gt;
+              &lt;im ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 311, Column 15</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=8"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=8'); return false;" 
+               target="_new"><code>img</code> element may require a long description.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/GitHub-Mark-Light-64px.png&quot; class=&quot;footer-logo&quot; alt=&quot;ACDH&quot; title=&quot;Gith ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/GitHub-Mark-Light-64px.png" height="50" border="1" alt="ACDH" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 311, Column 15</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=14"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=14'); return false;" 
+               target="_new">Image may be using color alone.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/GitHub-Mark-Light-64px.png&quot; class=&quot;footer-logo&quot; alt=&quot;ACDH&quot; title=&quot;Gith ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/GitHub-Mark-Light-64px.png" height="50" border="1" alt="ACDH" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 311, Column 15</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=251"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=251'); return false;" 
+               target="_new">Image may contain text with poor contrast.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/GitHub-Mark-Light-64px.png&quot; class=&quot;footer-logo&quot; alt=&quot;ACDH&quot; title=&quot;Gith ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/GitHub-Mark-Light-64px.png" height="50" border="1" alt="ACDH" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 311, Column 15</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=11"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=11'); return false;" 
+               target="_new">Image may contain text that is not in Alt text.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/GitHub-Mark-Light-64px.png&quot; class=&quot;footer-logo&quot; alt=&quot;ACDH&quot; title=&quot;Gith ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/GitHub-Mark-Light-64px.png" height="50" border="1" alt="ACDH" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 311, Column 15</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=16"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=16'); return false;" 
+               target="_new">Alt text is not empty and image may be decorative.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/GitHub-Mark-Light-64px.png&quot; class=&quot;footer-logo&quot; alt=&quot;ACDH&quot; title=&quot;Gith ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/GitHub-Mark-Light-64px.png" height="50" border="1" alt="ACDH" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 311, Column 15</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=239"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=239'); return false;" 
+               target="_new"><code>img</code> has <code>title</code> attribute and image may be decorative.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/GitHub-Mark-Light-64px.png&quot; class=&quot;footer-logo&quot; alt=&quot;ACDH&quot; title=&quot;Gith ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/GitHub-Mark-Light-64px.png" height="50" border="1" alt="ACDH" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 315, Column 11</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=197"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=197'); return false;" 
+               target="_new">Anchor text may not identify the link destination.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;http://www.ucl.ac.uk/dh/&quot; class=&quot;navlink&quot; target=&quot;_blank&quot;&gt;
+              &lt;img src=&quot;/static/ ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 315, Column 11</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=19"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=19'); return false;" 
+               target="_new">Link text may not be meaningful.</a>
+         </span>
+         <pre><code class="input">&lt;a href=&quot;http://www.ucl.ac.uk/dh/&quot; class=&quot;navlink&quot; target=&quot;_blank&quot;&gt;
+              &lt;img src=&quot;/static/ ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 316, Column 15</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=8"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=8'); return false;" 
+               target="_new"><code>img</code> element may require a long description.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/ucldh.png&quot; class=&quot;footer-logo&quot; alt=&quot;UCLDH&quot; title=&quot;UCL Centre for Digit ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/ucldh.png" height="50" border="1" alt="UCLDH" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 316, Column 15</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=14"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=14'); return false;" 
+               target="_new">Image may be using color alone.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/ucldh.png&quot; class=&quot;footer-logo&quot; alt=&quot;UCLDH&quot; title=&quot;UCL Centre for Digit ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/ucldh.png" height="50" border="1" alt="UCLDH" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 316, Column 15</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=251"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=251'); return false;" 
+               target="_new">Image may contain text with poor contrast.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/ucldh.png&quot; class=&quot;footer-logo&quot; alt=&quot;UCLDH&quot; title=&quot;UCL Centre for Digit ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/ucldh.png" height="50" border="1" alt="UCLDH" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 316, Column 15</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=11"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=11'); return false;" 
+               target="_new">Image may contain text that is not in Alt text.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/ucldh.png&quot; class=&quot;footer-logo&quot; alt=&quot;UCLDH&quot; title=&quot;UCL Centre for Digit ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/ucldh.png" height="50" border="1" alt="UCLDH" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 316, Column 15</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=16"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=16'); return false;" 
+               target="_new">Alt text is not empty and image may be decorative.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/ucldh.png&quot; class=&quot;footer-logo&quot; alt=&quot;UCLDH&quot; title=&quot;UCL Centre for Digit ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/ucldh.png" height="50" border="1" alt="UCLDH" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 316, Column 15</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=239"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=239'); return false;" 
+               target="_new"><code>img</code> has <code>title</code> attribute and image may be decorative.</a>
+         </span>
+         <pre><code class="input">&lt;img src=&quot;/static/webpage/img/ucldh.png&quot; class=&quot;footer-logo&quot; alt=&quot;UCLDH&quot; title=&quot;UCL Centre for Digit ...</code></pre>
+         <img src="https://dig-ed-cat.eos.arz.oeaw.ac.at/static/webpage/img/ucldh.png" height="50" border="1" alt="UCLDH" />
+
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 323, Column 5</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=89"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=89'); return false;" 
+               target="_new"><code>script</code> user interface may not be accessible.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot; src=&quot;/static/webpage/libraries/bootstrap335/js/bootstrap.min.js&quot;&gt;&lt;/sc ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 323, Column 5</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=86"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=86'); return false;" 
+               target="_new"><code>script</code> may use color alone.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot; src=&quot;/static/webpage/libraries/bootstrap335/js/bootstrap.min.js&quot;&gt;&lt;/sc ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 323, Column 5</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=87"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=87'); return false;" 
+               target="_new"><code>script</code> may cause screen flicker.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot; src=&quot;/static/webpage/libraries/bootstrap335/js/bootstrap.min.js&quot;&gt;&lt;/sc ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 324, Column 5</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=89"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=89'); return false;" 
+               target="_new"><code>script</code> user interface may not be accessible.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot; src=&quot;/static/webpage/libraries/bootstrap335/js/bootstrap-tab.js&quot;&gt;&lt;/sc ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 324, Column 5</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=86"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=86'); return false;" 
+               target="_new"><code>script</code> may use color alone.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot; src=&quot;/static/webpage/libraries/bootstrap335/js/bootstrap-tab.js&quot;&gt;&lt;/sc ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 324, Column 5</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=87"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=87'); return false;" 
+               target="_new"><code>script</code> may cause screen flicker.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot; src=&quot;/static/webpage/libraries/bootstrap335/js/bootstrap-tab.js&quot;&gt;&lt;/sc ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 325, Column 5</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=89"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=89'); return false;" 
+               target="_new"><code>script</code> user interface may not be accessible.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot; src=&quot;/static/webpage/libraries/jquery-ui-1.11.4/jquery-ui.min.js&quot;&gt;&lt;/s ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 325, Column 5</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=86"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=86'); return false;" 
+               target="_new"><code>script</code> may use color alone.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot; src=&quot;/static/webpage/libraries/jquery-ui-1.11.4/jquery-ui.min.js&quot;&gt;&lt;/s ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 325, Column 5</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=87"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=87'); return false;" 
+               target="_new"><code>script</code> may cause screen flicker.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot; src=&quot;/static/webpage/libraries/jquery-ui-1.11.4/jquery-ui.min.js&quot;&gt;&lt;/s ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 327, Column 7</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=89"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=89'); return false;" 
+               target="_new"><code>script</code> user interface may not be accessible.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot;&gt;
+        $(function (){
+          var options = {
+            twitter ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 327, Column 7</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=86"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=86'); return false;" 
+               target="_new"><code>script</code> may use color alone.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot;&gt;
+        $(function (){
+          var options = {
+            twitter ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 327, Column 7</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=87"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=87'); return false;" 
+               target="_new"><code>script</code> may cause screen flicker.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot;&gt;
+        $(function (){
+          var options = {
+            twitter ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 342, Column 7</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=89"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=89'); return false;" 
+               target="_new"><code>script</code> user interface may not be accessible.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot;&gt;
+              // Setup plugin with default settings
+              $( ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 342, Column 7</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=86"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=86'); return false;" 
+               target="_new"><code>script</code> may use color alone.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot;&gt;
+              // Setup plugin with default settings
+              $( ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+      <li class="msg_info">
+         <span class="err_type"><img src="https://achecker.ca/images/info.png" alt="Manual Check Required" title="Manual Check Required" width="15" height="15" /></span>
+         <em>Line 342, Column 7</em>:
+         <span class="msg">
+            <a href="https://achecker.ca/checker/suggestion.php?id=87"
+               onclick="AChecker.popup('https://achecker.ca/checker/suggestion.php?id=87'); return false;" 
+               target="_new"><code>script</code> may cause screen flicker.</a>
+         </span>
+         <pre><code class="input">&lt;script type=&quot;text/javascript&quot;&gt;
+              // Setup plugin with default settings
+              $( ...</code></pre>
+         
+         <p class="helpwanted">
+         </p>
+         
+         
+         
+       </li>
+</ul>
+</div>
+
+</body></html>


### PR DESCRIPTION
Hi, I did another check of the app with the AChecker and we passed with flying colours. The new HTML page in this PR is the official confirmation. Is there somewhere we could put this page? Maybe at the bottom of the homepage? For example "This site is mobile friendly and complies with the Accessibility Review WCAG 2.0 (Level AA) Guidelines.", where 'Accessibility Review bla bla" is linked to the HTML confirmation.
Alternatively, I have the same confirmation as PDF. Let me know what you prefer.