### PR TITLE
Updates

### DIFF
--- a/webpage/templates/webpage/documentation.html
+++ b/webpage/templates/webpage/documentation.html
@@ -49,10 +49,10 @@
         </div>
 
         <!--Progress-->
-        <div id="section5">
+        <!--<div id="section5">
             <h3>Progress</h3>
             <p>As of early 2017, the web application is still in its beta phase and despite a few bugs we're making good progress on both data accuracy and front/back-end development.</p>
-        </div>
+        </div>-->
 
 
         <!--Limitations-->

--- a/webpage/templates/webpage/output.html
+++ b/webpage/templates/webpage/output.html
@@ -1,0 +1,45 @@
+{% extends "webpage/base.html" %}
+{% load staticfiles %}
+
+{% block content %}
+<div class="container">
+
+<h1>Research output and visibility</h1>
+<br>
+
+	<h2>Publications and posters</h2>
+	<ul>
+		<li>Franzini, G., Andorfer, P., Zaytseva, K. (2016) <em>The Digital Editions Catalogue App: A web application to browse, curate and analyse digital
+editions</em>. TEI Conference 2016. Vienna, 26-30 September. DOI: <a href="https://doi.org/10.13140/RG.2.2.11868.59521 " title="Opens in new tab" target="_blank">10.13140/RG.2.2.11868.59521</a></li>
+
+		<li>Franzini, G., Mahony, S., and Terras, M. (2016), 'A Catalogue of Digital Editions', In: Pierazzo, E. and Driscoll, M. J. (eds) <em><a href="http://www.openbookpublishers.com/htmlreader/978-1-78374-238-7/ch9.xhtml#_idTextAnchor023" target="_blank" title="Opens in new tab">Digital Scholarly Editing: Theories and Practices</a></em>. Cambridge: Open Book Publishers. [<strong>describes an early version</strong> of the <em>Catalogue of Digital Editions</em>]</li>
+	</ul>
+
+
+
+	<h2>Conference presentations and invited talks</h2>
+	<ul>
+		<li>Franzini, G. (2017) *TBA*</li>
+		<li>Franzini, G. (2013) <em>A Catalogue of Digital Editions</em>. Digital Humanities Annual Conference. Lincoln, University of Nebraska, 18 July.</li>
+		<li>Franzini, G. (2013) <em>A Catalogue of Digital Editions: Towards an Electronic Edition of St. Augustine’s De civitate Dei</em>. Digital Classicist Seminar Series. London, Institute of Classical Studies, 12 July.</li>
+		<li>Franzini, G. (2012) <em>A Catalogue of Digital Editions: The prototype</em>. NeDiMAH Expert Meeting and Workshop on Digital Scholarly Editions. The Hague, 21 November.</li>
+	</ul>
+
+
+
+
+	<h2>Syndication</h2>
+	<p>The <em>Catalogue of Digital Editions</em> was added to the German <a href="http://rzblx10.uni-regensburg.de/dbinfo/detail.php?bib_id=allefreien&colors=&ocolors=&lett=k&tid=0&titel_id=102043" target="_target" title="Opens in new tab">Datenbank-Infosystem (DBIS)</a> for use in 317 libraries. DBIS was established at the University of Regensburg and is jointly funded by the Bavarian Ministry of Science, Research and the Arts and the German Research Foundation (DFG).</p>
+
+
+
+
+	<h2>Press and refbacks</h2>
+	<ul>
+		<li>2017-06-22. <em><a href="http://digitallatin.org/blog/library-digital-latin-texts-ldlt" target="_blank" title="Opens in new tab">The Library of Digital Latin Texts (LDLT)</a></em>, The Digital Latin Library.</li>
+		<li>2017-05-27. <em><a href="http://karelsykora.blog.idnes.cz/blog.aspx?c=606254" target="_blank" title="Opens in new tab">Katalog digitálních projektů</a></em>, iDNES.cz.</li>
+	</ul>
+
+
+</div>
+{% endblock %}


### PR DESCRIPTION
Minor change in Documentation; added an 'output' page, to be displayed, if possible, before the 'Documentation' tab in the right navbar?